### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/nexus-orchestrator/package.json
+++ b/nexus-orchestrator/package.json
@@ -15,7 +15,8 @@
     "form-data": "^4.0.0",
     "multer": "^2.0.1",
     "pg": "^8.11.3",
-    "socket.io": "^4.7.4"
+    "socket.io": "^4.7.4",
+    "express-rate-limit": "^7.5.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"


### PR DESCRIPTION
Potential fix for [https://github.com/peteywee/nexus-platform-project/security/code-scanning/5](https://github.com/peteywee/nexus-platform-project/security/code-scanning/5)

To fix the issue, we will add rate limiting to the application using the `express-rate-limit` package. This middleware will limit the number of requests a client can make to the `/command` endpoint within a specified time window. Specifically, we will:

1. Install the `express-rate-limit` package if it is not already installed.
2. Configure a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
3. Apply the rate limiter to the `/command` route handler.

This approach ensures that the `/command` endpoint is protected from abuse while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
